### PR TITLE
Add validation when sim card is not inserted for Android <= 7

### DIFF
--- a/sample/src/main/java/com/twilio/sample/WelcomeFragment.kt
+++ b/sample/src/main/java/com/twilio/sample/WelcomeFragment.kt
@@ -18,6 +18,7 @@ package com.twilio.sample
 import android.content.Context
 import android.net.ConnectivityManager
 import android.os.Bundle
+import android.telephony.TelephonyManager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -99,6 +100,11 @@ class WelcomeFragment : Fragment() {
    * Taken from https://stackoverflow.com/a/8243305
    */
   private fun isMobileDataEnabled(cm: ConnectivityManager): Boolean {
+    val telephonyManager = requireActivity().getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
+    if (telephonyManager.simState != TelephonyManager.SIM_STATE_READY) {
+      return false
+    }
+
     return try {
       val c = Class.forName(cm.javaClass.name)
       val m: Method = c.getDeclaredMethod("getMobileDataEnabled")


### PR DESCRIPTION
<!-- Thanks for contributing to Twilio Verify SNA. Please consider this template for your PR -->
<!-- Title format: [Ticket Number/Issue Number] - Brief description -->
<!-- Assignee: Please assign yourself to this PR -->
<!-- Labels: Please add proper labels accordingly (bug, documentation, enhancement, ...) -->

<!-- Ticket: Please add the ticket number or the Github issue number according to your case -->

## Ticket

N/A

## Github Issue

N/A

<!-- Description: Please add a detailed description of your contribution. Include associated PRs or dependencies. If you're opening an integration PR, please add proper checklist of remaining items and tag this PR with a "DO NOT MERGE YET" -->

## Description

Validate when the device does not have a sim inserted in versions of Android 7 and older. Return toast message "`For silent network authentication, you will need a working sim card`".

<!-- Commit message: Use Conventional commits https://www.conventionalcommits.org/en/v1.0.0/-->

## Commit message

- Add validation when sim card is not inserted for Android <= 7

<!-- Screenshot: When possible add a screenshot or gif showing your changes if not you can remove this section -->

## Screenshot

https://github.com/twilio/twilio-verify-sna-android/assets/96069697/be306516-ba56-48eb-b72e-fd6be2d695f4



## Testing

- [ ] Added unit tests
- [x] Ran unit tests successfully
- [ ] Added documentation for public APIs and/or Wiki
