### PR TITLE
fix: SNA Android stability improvements (CAS-996)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ The app will ask the network carrier if the provided phone number is the same us
 | CellularNetworkNotAvailable | Cellular network not available                       | Cellular network not available, check if the device has cellular internet connection or you are not using a simulator or tablet. |
 | NoResultFromUrl             | Unable to get a valid result from the requested URL. | Unable to get a redirection path or a result path from the url, probably the SNA URL is corrupted (or maybe expired)             |
 | NetworkRequestException     | Error processing the network request.                | An error was thrown in the network layer, check the inner exception property for more details.                                   |
+| NetworkRequestTimeoutException | The network request timed out.                    | The cellular network did not become available within the timeout window, e.g. no cellular coverage or the network never validated. |
 | RunInMainThreadException    | The SDK detected it was running in the main thread.  | The SDK is performing long-time tasks that can freeze or stop the app, it's required to run the SDK in a background thread.      |
 | UnexpectedException         | An unknown error was thrown.                         | Check the inner exception for more details.                                                                                      |
 

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -16,6 +16,8 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.twilio.verify.sna.sample">
 
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
   <uses-permission android:name="android.permission.CHANGE_NETWORK_STATE" />
 
   <uses-permission android:name="android.permission.INTERNET" />

--- a/sample/src/main/java/com/twilio/verify/sna/sample/VerifyingFragment.kt
+++ b/sample/src/main/java/com/twilio/verify/sna/sample/VerifyingFragment.kt
@@ -37,9 +37,7 @@ class VerifyingFragment : Fragment() {
 
   private val args: VerifyingFragmentArgs by navArgs()
 
-  // Create TwilioVerifySna instance using builder.
-  // Uses the application context so the SDK never holds (or requires) an attached fragment
-  // context, avoiding "Fragment not attached to a context" crashes.
+  // Create TwilioVerifySna instance using builder
   private val twilioVerifySna: TwilioVerifySna by lazy {
     TwilioVerifySna
       .Builder(requireContext().applicationContext)
@@ -70,8 +68,6 @@ class VerifyingFragment : Fragment() {
    * 3. Check with the backend URL provided if verification was successful.
    */
   private fun invokeVerifySna() {
-    // Use the view's lifecycle scope so the coroutine is cancelled when the view is destroyed
-    // (e.g. the user presses back mid-verification), preventing navigation on a dead fragment.
     viewLifecycleOwner.lifecycleScope.launch {
       val snaUrl = getSnaUrl(args.backendUrl, args.phoneNumber)
       if (snaUrl.isNullOrEmpty()) {

--- a/sample/src/main/java/com/twilio/verify/sna/sample/VerifyingFragment.kt
+++ b/sample/src/main/java/com/twilio/verify/sna/sample/VerifyingFragment.kt
@@ -37,10 +37,12 @@ class VerifyingFragment : Fragment() {
 
   private val args: VerifyingFragmentArgs by navArgs()
 
-  // Create TwilioVerifySna instance using builder
+  // Create TwilioVerifySna instance using builder.
+  // Uses the application context so the SDK never holds (or requires) an attached fragment
+  // context, avoiding "Fragment not attached to a context" crashes.
   private val twilioVerifySna: TwilioVerifySna by lazy {
     TwilioVerifySna
-      .Builder(requireContext())
+      .Builder(requireContext().applicationContext)
       .build()
   }
 
@@ -68,7 +70,9 @@ class VerifyingFragment : Fragment() {
    * 3. Check with the backend URL provided if verification was successful.
    */
   private fun invokeVerifySna() {
-    lifecycleScope.launch {
+    // Use the view's lifecycle scope so the coroutine is cancelled when the view is destroyed
+    // (e.g. the user presses back mid-verification), preventing navigation on a dead fragment.
+    viewLifecycleOwner.lifecycleScope.launch {
       val snaUrl = getSnaUrl(args.backendUrl, args.phoneNumber)
       if (snaUrl.isNullOrEmpty()) {
         onFail()
@@ -135,6 +139,7 @@ class VerifyingFragment : Fragment() {
    * Redirect to successful validation screen
    */
   private fun onSuccess() {
+    if (!isAdded) return
     val action = VerifyingFragmentDirections
       .actionVerifyingFragmentToVerificationSuccessfulFragment()
     findNavController().navigate(action)
@@ -144,6 +149,7 @@ class VerifyingFragment : Fragment() {
    * Redirect to failed validation screen
    */
   private fun onFail() {
+    if (!isAdded) return
     val action = VerifyingFragmentDirections
       .actionVerifyingFragmentToVerificationFailedFragment()
     findNavController().navigate(action)

--- a/sample/src/main/java/com/twilio/verify/sna/sample/WelcomeFragment.kt
+++ b/sample/src/main/java/com/twilio/verify/sna/sample/WelcomeFragment.kt
@@ -16,8 +16,6 @@
 package com.twilio.verify.sna.sample
 
 import android.content.Context
-import android.net.ConnectivityManager
-import android.os.Build
 import android.os.Bundle
 import android.telephony.TelephonyManager
 import android.view.LayoutInflater
@@ -27,7 +25,8 @@ import android.widget.Toast
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.twilio.verify.sna.sample.databinding.FragmentWelcomeBinding
-import java.lang.reflect.Method
+import com.twilio.verify_sna.networking.IsMobileDataEnabledHelper
+import com.twilio.verify_sna.networking.IsMobileDataEnabledHelperImpl
 
 private const val PHONE_NUMBER_KEY = "phoneNumber"
 private const val BACKEND_URL_KEY = "backendUrl"
@@ -35,6 +34,10 @@ private const val BACKEND_URL_KEY = "backendUrl"
 class WelcomeFragment : Fragment() {
 
   private lateinit var binding: FragmentWelcomeBinding
+
+  private val isMobileDataEnabledHelper: IsMobileDataEnabledHelper by lazy {
+    IsMobileDataEnabledHelperImpl(requireContext().applicationContext)
+  }
 
   override fun onCreateView(
     inflater: LayoutInflater,
@@ -107,41 +110,10 @@ class WelcomeFragment : Fragment() {
       return CellularCoverageStatus.SIM_NOT_READY
     }
 
-    val connectivityManager = requireContext().getSystemService(
-      Context.CONNECTIVITY_SERVICE
-    ) as ConnectivityManager
-
-    return if (isMobileDataEnabled(telephonyManager, connectivityManager)) {
+    return if (isMobileDataEnabledHelper()) {
       CellularCoverageStatus.AVAILABLE
     } else {
       CellularCoverageStatus.MOBILE_DATA_DISABLED
-    }
-  }
-
-  /**
-   * Android Framework doesn't count with a pre-build way of getting mobile network status,
-   * when Wi-Fi is active. Reflection fits well.
-   * Taken from https://stackoverflow.com/a/8243305
-   */
-  private fun isMobileDataEnabled(
-    telephonyManager: TelephonyManager,
-    cm: ConnectivityManager
-  ): Boolean {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      return try {
-        telephonyManager.isDataEnabled
-      } catch (securityException: SecurityException) {
-        false
-      }
-    }
-
-    return try {
-      val c = Class.forName(cm.javaClass.name)
-      val m: Method = c.getDeclaredMethod("getMobileDataEnabled")
-      m.isAccessible = true
-      m.invoke(cm) as Boolean
-    } catch (exception: Exception) {
-      false
     }
   }
 

--- a/sample/src/main/java/com/twilio/verify/sna/sample/WelcomeFragment.kt
+++ b/sample/src/main/java/com/twilio/verify/sna/sample/WelcomeFragment.kt
@@ -74,9 +74,16 @@ class WelcomeFragment : Fragment() {
     }
     // save in cache the phone number and backend URL
     saveInPreferences(phoneNumber, backendUrl)
-    if (!hasCellularCoverage()) {
-      showErrorMessage(R.string.cellular_network_required)
-      return
+    when (cellularCoverageStatus()) {
+      CellularCoverageStatus.SIM_NOT_READY -> {
+        showErrorMessage(R.string.sim_not_ready_error)
+        return
+      }
+      CellularCoverageStatus.MOBILE_DATA_DISABLED -> {
+        showErrorMessage(R.string.mobile_data_disabled_error)
+        return
+      }
+      CellularCoverageStatus.AVAILABLE -> Unit
     }
     val action = WelcomeFragmentDirections
       .actionWelcomeFragmentToVerifyingFragment(
@@ -90,14 +97,25 @@ class WelcomeFragment : Fragment() {
   }
 
   /**
-   * Verifies cellular network is on
+   * Verifies cellular network is on, returning the specific reason when it isn't so the user
+   * can be told what to do about it.
    */
-  private fun hasCellularCoverage(): Boolean {
+  private fun cellularCoverageStatus(): CellularCoverageStatus {
+    val telephonyManager =
+      requireActivity().getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
+    if (telephonyManager.simState != TelephonyManager.SIM_STATE_READY) {
+      return CellularCoverageStatus.SIM_NOT_READY
+    }
+
     val connectivityManager = requireContext().getSystemService(
       Context.CONNECTIVITY_SERVICE
     ) as ConnectivityManager
 
-    return isMobileDataEnabled(connectivityManager)
+    return if (isMobileDataEnabled(telephonyManager, connectivityManager)) {
+      CellularCoverageStatus.AVAILABLE
+    } else {
+      CellularCoverageStatus.MOBILE_DATA_DISABLED
+    }
   }
 
   /**
@@ -105,12 +123,10 @@ class WelcomeFragment : Fragment() {
    * when Wi-Fi is active. Reflection fits well.
    * Taken from https://stackoverflow.com/a/8243305
    */
-  private fun isMobileDataEnabled(cm: ConnectivityManager): Boolean {
-    val telephonyManager = requireActivity().getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
-    if (telephonyManager.simState != TelephonyManager.SIM_STATE_READY) {
-      return false
-    }
-
+  private fun isMobileDataEnabled(
+    telephonyManager: TelephonyManager,
+    cm: ConnectivityManager
+  ): Boolean {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
       return try {
         telephonyManager.isDataEnabled
@@ -138,5 +154,11 @@ class WelcomeFragment : Fragment() {
       putString(BACKEND_URL_KEY, backendUrl)
       apply()
     }
+  }
+
+  private enum class CellularCoverageStatus {
+    AVAILABLE,
+    SIM_NOT_READY,
+    MOBILE_DATA_DISABLED
   }
 }

--- a/sample/src/main/java/com/twilio/verify/sna/sample/WelcomeFragment.kt
+++ b/sample/src/main/java/com/twilio/verify/sna/sample/WelcomeFragment.kt
@@ -131,7 +131,6 @@ class WelcomeFragment : Fragment() {
       return try {
         telephonyManager.isDataEnabled
       } catch (securityException: SecurityException) {
-        securityException.printStackTrace()
         false
       }
     }
@@ -142,7 +141,6 @@ class WelcomeFragment : Fragment() {
       m.isAccessible = true
       m.invoke(cm) as Boolean
     } catch (exception: Exception) {
-      exception.printStackTrace()
       false
     }
   }

--- a/sample/src/main/java/com/twilio/verify/sna/sample/WelcomeFragment.kt
+++ b/sample/src/main/java/com/twilio/verify/sna/sample/WelcomeFragment.kt
@@ -17,6 +17,7 @@ package com.twilio.verify.sna.sample
 
 import android.content.Context
 import android.net.ConnectivityManager
+import android.os.Build
 import android.os.Bundle
 import android.telephony.TelephonyManager
 import android.view.LayoutInflater
@@ -100,14 +101,25 @@ class WelcomeFragment : Fragment() {
   }
 
   /**
-   * Android Framework doesn't count with a pre-build way of getting mobile network status,
-   * when Wi-Fi is active. Reflection fits well.
-   * Taken from https://stackoverflow.com/a/8243305
+   * Checks whether mobile data is enabled.
+   *
+   * On Android O (API 26) and above we use the public [TelephonyManager.isDataEnabled] API. The
+   * old reflection approach (ConnectivityManager.getMobileDataEnabled) is greylisted/blocked on
+   * Android P+ and would always return false, wrongly blocking the flow on modern devices.
    */
   private fun isMobileDataEnabled(cm: ConnectivityManager): Boolean {
     val telephonyManager = requireActivity().getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
     if (telephonyManager.simState != TelephonyManager.SIM_STATE_READY) {
       return false
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      return try {
+        telephonyManager.isDataEnabled
+      } catch (securityException: SecurityException) {
+        securityException.printStackTrace()
+        false
+      }
     }
 
     return try {

--- a/sample/src/main/java/com/twilio/verify/sna/sample/WelcomeFragment.kt
+++ b/sample/src/main/java/com/twilio/verify/sna/sample/WelcomeFragment.kt
@@ -101,11 +101,9 @@ class WelcomeFragment : Fragment() {
   }
 
   /**
-   * Checks whether mobile data is enabled.
-   *
-   * On Android O (API 26) and above we use the public [TelephonyManager.isDataEnabled] API. The
-   * old reflection approach (ConnectivityManager.getMobileDataEnabled) is greylisted/blocked on
-   * Android P+ and would always return false, wrongly blocking the flow on modern devices.
+   * Android Framework doesn't count with a pre-build way of getting mobile network status,
+   * when Wi-Fi is active. Reflection fits well.
+   * Taken from https://stackoverflow.com/a/8243305
    */
   private fun isMobileDataEnabled(cm: ConnectivityManager): Boolean {
     val telephonyManager = requireActivity().getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -30,4 +30,6 @@
   <string name="successful_verification_description">We were able to verify your phone number automatically, now you can continue, welcome!</string>
   <string name="missing_field_error">Missing country code, phone number or backend URL.</string>
   <string name="cellular_network_required">For silent network authentication, you will need a working sim card.</string>
+  <string name="sim_not_ready_error">No active SIM detected. Insert a working SIM card to continue with silent network authentication.</string>
+  <string name="mobile_data_disabled_error">Mobile data is turned off. Enable mobile data in your device settings to continue with silent network authentication.</string>
 </resources>

--- a/verify_sna/src/main/java/com/twilio/verify_sna/TwilioVerifySna.kt
+++ b/verify_sna/src/main/java/com/twilio/verify_sna/TwilioVerifySna.kt
@@ -42,7 +42,7 @@ interface TwilioVerifySna {
 
     private var requestManager: RequestManager = ConcreteRequestManager(
       context,
-      IsMobileDataEnabledHelperImpl(),
+      IsMobileDataEnabledHelperImpl(context),
       VerifySnaNetworkCallbackProviderImpl(
         ConcreteNetworkRequestProvider()
       ),

--- a/verify_sna/src/main/java/com/twilio/verify_sna/common/TwilioVerifySnaException.kt
+++ b/verify_sna/src/main/java/com/twilio/verify_sna/common/TwilioVerifySnaException.kt
@@ -47,6 +47,11 @@ sealed class TwilioVerifySnaException(
     cause = exception
   )
 
+  object NetworkRequestTimeoutException : TwilioVerifySnaException(
+    description = "The network request timed out.",
+    technicalError = "The cellular network did not become available within the timeout window."
+  )
+
   object RunInMainThreadException : TwilioVerifySnaException(
     description = "Can't run inside main thread."
   )

--- a/verify_sna/src/main/java/com/twilio/verify_sna/domain/requestmanager/RequestManager.kt
+++ b/verify_sna/src/main/java/com/twilio/verify_sna/domain/requestmanager/RequestManager.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeout
 import kotlin.coroutines.resumeWithException
+import kotlin.time.Duration.Companion.milliseconds
 
 private const val NETWORK_TIMEOUT_MS = 30_000L
 
@@ -47,7 +48,7 @@ class ConcreteRequestManager(
 
   override suspend fun processUrl(url: String): NetworkRequestResult {
     return try {
-      withTimeout(NETWORK_TIMEOUT_MS) {
+      withTimeout(NETWORK_TIMEOUT_MS.milliseconds) {
         suspendCancellableCoroutine { continuation ->
           val connectivityManager = context.getSystemService(
             Context.CONNECTIVITY_SERVICE
@@ -58,7 +59,7 @@ class ConcreteRequestManager(
             )
             return@suspendCancellableCoroutine
           }
-          if (isMobileDataEnabledHelper(connectivityManager)) {
+          if (isMobileDataEnabledHelper()) {
             establishCellularConnection(connectivityManager, url, continuation)
           } else {
             continuation.resumeWithException(

--- a/verify_sna/src/main/java/com/twilio/verify_sna/domain/requestmanager/RequestManager.kt
+++ b/verify_sna/src/main/java/com/twilio/verify_sna/domain/requestmanager/RequestManager.kt
@@ -31,10 +31,6 @@ import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withTimeout
 import kotlin.coroutines.resumeWithException
 
-/**
- * Maximum time to wait for the cellular network callback to resume. If the cellular network
- * never becomes available/validated, the request is cancelled instead of hanging forever.
- */
 private const val NETWORK_TIMEOUT_MS = 30_000L
 
 interface RequestManager {
@@ -93,12 +89,10 @@ class ConcreteRequestManager(
       connectivityManager
     )
 
-    // If the request times out or is cancelled, unregister the callback so it doesn't leak.
     continuation.invokeOnCancellation {
       try {
         connectivityManager.unregisterNetworkCallback(networkCallback)
       } catch (e: IllegalArgumentException) {
-        // The callback may have already been unregistered on the success/failure path.
       }
     }
 

--- a/verify_sna/src/main/java/com/twilio/verify_sna/domain/requestmanager/RequestManager.kt
+++ b/verify_sna/src/main/java/com/twilio/verify_sna/domain/requestmanager/RequestManager.kt
@@ -101,6 +101,12 @@ class ConcreteRequestManager(
       connectivityManager,
       networkRequest,
       networkCallback
-    )
+    ) { requestNetworkException ->
+      // Both attempts failed, so the callback was never registered and nothing else will resume
+      // the continuation. Surface the cause instead of letting the caller wait out the timeout.
+      continuation.resumeWithException(
+        TwilioVerifySnaException.NetworkRequestException(requestNetworkException)
+      )
+    }
   }
 }

--- a/verify_sna/src/main/java/com/twilio/verify_sna/domain/requestmanager/RequestManager.kt
+++ b/verify_sna/src/main/java/com/twilio/verify_sna/domain/requestmanager/RequestManager.kt
@@ -25,9 +25,17 @@ import com.twilio.verify_sna.networking.IsMobileDataEnabledHelper
 import com.twilio.verify_sna.networking.NetworkRequestResult
 import com.twilio.verify_sna.networking.RequestNetworkWithRetryHelper
 import com.twilio.verify_sna.networking.VerifySnaNetworkCallbackProvider
-import kotlin.coroutines.Continuation
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeout
 import kotlin.coroutines.resumeWithException
-import kotlin.coroutines.suspendCoroutine
+
+/**
+ * Maximum time to wait for the cellular network callback to resume. If the cellular network
+ * never becomes available/validated, the request is cancelled instead of hanging forever.
+ */
+private const val NETWORK_TIMEOUT_MS = 30_000L
 
 interface RequestManager {
 
@@ -42,24 +50,36 @@ class ConcreteRequestManager(
 ) : RequestManager {
 
   override suspend fun processUrl(url: String): NetworkRequestResult {
-    return suspendCoroutine { continuation ->
-      val connectivityManager = context.getSystemService(
-        Context.CONNECTIVITY_SERVICE
-      ) as ConnectivityManager
-      if (isMobileDataEnabledHelper(connectivityManager)) {
-        establishCellularConnection(connectivityManager, url, continuation)
-      } else {
-        continuation.resumeWithException(
-          TwilioVerifySnaException.CellularNetworkNotAvailable
-        )
+    return try {
+      withTimeout(NETWORK_TIMEOUT_MS) {
+        suspendCancellableCoroutine { continuation ->
+          val connectivityManager = context.getSystemService(
+            Context.CONNECTIVITY_SERVICE
+          ) as? ConnectivityManager
+          if (connectivityManager == null) {
+            continuation.resumeWithException(
+              TwilioVerifySnaException.CellularNetworkNotAvailable
+            )
+            return@suspendCancellableCoroutine
+          }
+          if (isMobileDataEnabledHelper(connectivityManager)) {
+            establishCellularConnection(connectivityManager, url, continuation)
+          } else {
+            continuation.resumeWithException(
+              TwilioVerifySnaException.CellularNetworkNotAvailable
+            )
+          }
+        }
       }
+    } catch (timeout: TimeoutCancellationException) {
+      throw TwilioVerifySnaException.NetworkRequestException(timeout)
     }
   }
 
   private fun establishCellularConnection(
     connectivityManager: ConnectivityManager,
     url: String,
-    continuation: Continuation<NetworkRequestResult>
+    continuation: CancellableContinuation<NetworkRequestResult>
   ) {
     val networkRequestBuilder = NetworkRequest.Builder()
       .addTransportType(NetworkCapabilities.TRANSPORT_CELLULAR)
@@ -72,6 +92,15 @@ class ConcreteRequestManager(
       continuation,
       connectivityManager
     )
+
+    // If the request times out or is cancelled, unregister the callback so it doesn't leak.
+    continuation.invokeOnCancellation {
+      try {
+        connectivityManager.unregisterNetworkCallback(networkCallback)
+      } catch (e: IllegalArgumentException) {
+        // The callback may have already been unregistered on the success/failure path.
+      }
+    }
 
     requestNetworkWithRetryHelper(
       connectivityManager,

--- a/verify_sna/src/main/java/com/twilio/verify_sna/domain/requestmanager/RequestManager.kt
+++ b/verify_sna/src/main/java/com/twilio/verify_sna/domain/requestmanager/RequestManager.kt
@@ -68,7 +68,7 @@ class ConcreteRequestManager(
         }
       }
     } catch (timeout: TimeoutCancellationException) {
-      throw TwilioVerifySnaException.NetworkRequestException(timeout)
+      throw TwilioVerifySnaException.NetworkRequestTimeoutException
     }
   }
 

--- a/verify_sna/src/main/java/com/twilio/verify_sna/networking/IsMobileDataEnabledHelper.kt
+++ b/verify_sna/src/main/java/com/twilio/verify_sna/networking/IsMobileDataEnabledHelper.kt
@@ -5,20 +5,19 @@ import android.net.ConnectivityManager
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
 import android.telephony.TelephonyManager
-import java.lang.reflect.Method
 
 interface IsMobileDataEnabledHelper {
-  operator fun invoke(connectivityManager: ConnectivityManager): Boolean
+  /**
+   * Whether the mobile data user setting is on, regardless of Wi-Fi being the active network.
+   */
+  operator fun invoke(): Boolean
 }
 
 class IsMobileDataEnabledHelperImpl(
   private val context: Context
 ) : IsMobileDataEnabledHelper {
 
-  override fun invoke(connectivityManager: ConnectivityManager): Boolean {
-    // TelephonyManager.isDataEnabled() is a public API since Android O (API 26). Reflecting into
-    // the hidden ConnectivityManager.getMobileDataEnabled() is greylisted/blocked on Android P+
-    // and would throw, wrongly reporting mobile data as disabled on modern devices.
+  override fun invoke(): Boolean {
     if (VERSION.SDK_INT >= VERSION_CODES.O) {
       val telephonyManager =
         context.getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager
@@ -28,20 +27,23 @@ class IsMobileDataEnabledHelperImpl(
         false
       }
     }
-    return isMobileDataEnabledByReflection(connectivityManager)
+    return isMobileDataEnabledByReflection()
   }
 
   /**
-   * Android Framework doesn't count with a pre-build way of getting mobile network status,
-   * when Wi-Fi is active. Reflection fits well.
+   * There is no public API for the mobile data setting below Android O (API 26), where
+   * TelephonyManager.isDataEnabled() was added, so pre-O devices read the hidden
+   * ConnectivityManager.getMobileDataEnabled().
    * Taken from https://stackoverflow.com/a/8243305
    */
-  private fun isMobileDataEnabledByReflection(connectivityManager: ConnectivityManager): Boolean {
+  private fun isMobileDataEnabledByReflection(): Boolean {
     return try {
-      val c = Class.forName(connectivityManager.javaClass.name)
-      val m: Method = c.getDeclaredMethod("getMobileDataEnabled")
-      m.isAccessible = true
-      m.invoke(connectivityManager) as Boolean
+      val connectivityManager =
+        context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+          ?: return false
+      val method = connectivityManager.javaClass.getDeclaredMethod("getMobileDataEnabled")
+      method.isAccessible = true
+      method.invoke(connectivityManager) as Boolean
     } catch (exception: Exception) {
       false
     }

--- a/verify_sna/src/main/java/com/twilio/verify_sna/networking/IsMobileDataEnabledHelper.kt
+++ b/verify_sna/src/main/java/com/twilio/verify_sna/networking/IsMobileDataEnabledHelper.kt
@@ -1,20 +1,47 @@
 package com.twilio.verify_sna.networking
 
+import android.content.Context
 import android.net.ConnectivityManager
+import android.os.Build.VERSION
+import android.os.Build.VERSION_CODES
+import android.telephony.TelephonyManager
 import java.lang.reflect.Method
 
 interface IsMobileDataEnabledHelper {
   operator fun invoke(connectivityManager: ConnectivityManager): Boolean
 }
 
-class IsMobileDataEnabledHelperImpl : IsMobileDataEnabledHelper {
+class IsMobileDataEnabledHelperImpl(
+  private val context: Context
+) : IsMobileDataEnabledHelper {
+
+  override fun invoke(connectivityManager: ConnectivityManager): Boolean {
+    // TelephonyManager.isDataEnabled() is a public API since Android O (API 26). Reflecting into
+    // the hidden ConnectivityManager.getMobileDataEnabled() is greylisted/blocked on Android P+
+    // and would throw, wrongly reporting mobile data as disabled on modern devices.
+    if (VERSION.SDK_INT >= VERSION_CODES.O) {
+      val telephonyManager =
+        context.getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager
+      return try {
+        telephonyManager?.isDataEnabled ?: false
+      } catch (securityException: SecurityException) {
+        // isDataEnabled may require READ_PHONE_STATE on some devices/OS versions. The SDK does not
+        // declare that permission, so treat a denial as "not available" rather than crashing.
+        securityException.printStackTrace()
+        false
+      }
+    }
+    return isMobileDataEnabledByReflection(connectivityManager)
+  }
 
   /**
    * Android Framework doesn't count with a pre-build way of getting mobile network status,
    * when Wi-Fi is active. Reflection fits well.
    * Taken from https://stackoverflow.com/a/8243305
+   *
+   * Only used below Android O, where the hidden API is still accessible.
    */
-  override fun invoke(connectivityManager: ConnectivityManager): Boolean {
+  private fun isMobileDataEnabledByReflection(connectivityManager: ConnectivityManager): Boolean {
     return try {
       val c = Class.forName(connectivityManager.javaClass.name)
       val m: Method = c.getDeclaredMethod("getMobileDataEnabled")

--- a/verify_sna/src/main/java/com/twilio/verify_sna/networking/IsMobileDataEnabledHelper.kt
+++ b/verify_sna/src/main/java/com/twilio/verify_sna/networking/IsMobileDataEnabledHelper.kt
@@ -25,7 +25,8 @@ class IsMobileDataEnabledHelperImpl(
       return try {
         telephonyManager?.isDataEnabled ?: false
       } catch (securityException: SecurityException) {
-        securityException.printStackTrace()
+        // Recoverable: treat an undeterminable data state as "not available". A logging hook
+        // will report this once the SDK has a logging mechanism.
         false
       }
     }
@@ -44,7 +45,8 @@ class IsMobileDataEnabledHelperImpl(
       m.isAccessible = true
       m.invoke(connectivityManager) as Boolean
     } catch (exception: Exception) {
-      exception.printStackTrace()
+      // Recoverable: treat an undeterminable data state as "not available". A logging hook
+      // will report this once the SDK has a logging mechanism.
       false
     }
   }

--- a/verify_sna/src/main/java/com/twilio/verify_sna/networking/IsMobileDataEnabledHelper.kt
+++ b/verify_sna/src/main/java/com/twilio/verify_sna/networking/IsMobileDataEnabledHelper.kt
@@ -25,8 +25,6 @@ class IsMobileDataEnabledHelperImpl(
       return try {
         telephonyManager?.isDataEnabled ?: false
       } catch (securityException: SecurityException) {
-        // isDataEnabled may require READ_PHONE_STATE on some devices/OS versions. The SDK does not
-        // declare that permission, so treat a denial as "not available" rather than crashing.
         securityException.printStackTrace()
         false
       }
@@ -38,8 +36,6 @@ class IsMobileDataEnabledHelperImpl(
    * Android Framework doesn't count with a pre-build way of getting mobile network status,
    * when Wi-Fi is active. Reflection fits well.
    * Taken from https://stackoverflow.com/a/8243305
-   *
-   * Only used below Android O, where the hidden API is still accessible.
    */
   private fun isMobileDataEnabledByReflection(connectivityManager: ConnectivityManager): Boolean {
     return try {

--- a/verify_sna/src/main/java/com/twilio/verify_sna/networking/IsMobileDataEnabledHelper.kt
+++ b/verify_sna/src/main/java/com/twilio/verify_sna/networking/IsMobileDataEnabledHelper.kt
@@ -25,8 +25,6 @@ class IsMobileDataEnabledHelperImpl(
       return try {
         telephonyManager?.isDataEnabled ?: false
       } catch (securityException: SecurityException) {
-        // Recoverable: treat an undeterminable data state as "not available". A logging hook
-        // will report this once the SDK has a logging mechanism.
         false
       }
     }
@@ -45,8 +43,6 @@ class IsMobileDataEnabledHelperImpl(
       m.isAccessible = true
       m.invoke(connectivityManager) as Boolean
     } catch (exception: Exception) {
-      // Recoverable: treat an undeterminable data state as "not available". A logging hook
-      // will report this once the SDK has a logging mechanism.
       false
     }
   }

--- a/verify_sna/src/main/java/com/twilio/verify_sna/networking/NetworkRequestProvider.kt
+++ b/verify_sna/src/main/java/com/twilio/verify_sna/networking/NetworkRequestProvider.kt
@@ -21,6 +21,7 @@ import com.twilio.verify_sna.common.TwilioVerifySnaException
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
 import okhttp3.Request
+import java.io.IOException
 
 interface NetworkRequestProvider {
 
@@ -41,7 +42,13 @@ class ConcreteNetworkRequestProvider : NetworkRequestProvider {
       )
       .build()
     val request = Request.Builder().url(urlText).build()
-    val response = okHttpClient.newCall(request).execute()
+    val response = try {
+      okHttpClient.newCall(request).execute()
+    } catch (e: IOException) {
+      // Network errors, DNS failures, etc. are surfaced as a typed exception instead of an
+      // uncaught IOException.
+      throw TwilioVerifySnaException.NetworkRequestException(e)
+    }
     if (response.isSuccessful) {
       val status = response.code
       val message = response.body?.string()

--- a/verify_sna/src/main/java/com/twilio/verify_sna/networking/NetworkRequestProvider.kt
+++ b/verify_sna/src/main/java/com/twilio/verify_sna/networking/NetworkRequestProvider.kt
@@ -42,18 +42,21 @@ class ConcreteNetworkRequestProvider : NetworkRequestProvider {
       )
       .build()
     val request = Request.Builder().url(urlText).build()
-    val response = try {
-      okHttpClient.newCall(request).execute()
+    return try {
+      val response = okHttpClient.newCall(request).execute()
+      if (response.isSuccessful) {
+        val status = response.code
+        val message = response.body?.string()
+        NetworkRequestResult(status, message)
+      } else {
+        throw TwilioVerifySnaException.NetworkRequestException(
+          Exception("SNA_URL wasn't successful")
+        )
+      }
     } catch (e: IOException) {
-      // Network errors, DNS failures, etc. are surfaced as a typed exception instead of an
-      // uncaught IOException.
+      // Network errors, DNS failures, truncated reads, etc. are surfaced as a typed exception
+      // instead of an uncaught IOException.
       throw TwilioVerifySnaException.NetworkRequestException(e)
     }
-    if (response.isSuccessful) {
-      val status = response.code
-      val message = response.body?.string()
-      return NetworkRequestResult(status, message)
-    }
-    throw TwilioVerifySnaException.NetworkRequestException(Exception("SNA_URL wasn't successful"))
   }
 }

--- a/verify_sna/src/main/java/com/twilio/verify_sna/networking/NetworkRequestProvider.kt
+++ b/verify_sna/src/main/java/com/twilio/verify_sna/networking/NetworkRequestProvider.kt
@@ -54,8 +54,6 @@ class ConcreteNetworkRequestProvider : NetworkRequestProvider {
         )
       }
     } catch (e: IOException) {
-      // Network errors, DNS failures, truncated reads, etc. are surfaced as a typed exception
-      // instead of an uncaught IOException.
       throw TwilioVerifySnaException.NetworkRequestException(e)
     }
   }

--- a/verify_sna/src/main/java/com/twilio/verify_sna/networking/RequestNetworkWithRetryHelper.kt
+++ b/verify_sna/src/main/java/com/twilio/verify_sna/networking/RequestNetworkWithRetryHelper.kt
@@ -28,10 +28,17 @@ class RequestNetworkWithRetryHelperImpl : RequestNetworkWithRetryHelper {
       )
     } catch (e: Exception) {
       Handler(Looper.getMainLooper()).postDelayed({
-        connectivityManager.requestNetwork(
-          networkRequest,
-          networkCallback
-        )
+        // Guard the retry so a second failure doesn't crash the main thread. If the retry also
+        // fails the continuation won't resume here, but the timeout in RequestManager backstops
+        // that case by cancelling the request and unregistering the callback.
+        try {
+          connectivityManager.requestNetwork(
+            networkRequest,
+            networkCallback
+          )
+        } catch (retryException: Exception) {
+          retryException.printStackTrace()
+        }
       }, 500)
     }
   }

--- a/verify_sna/src/main/java/com/twilio/verify_sna/networking/RequestNetworkWithRetryHelper.kt
+++ b/verify_sna/src/main/java/com/twilio/verify_sna/networking/RequestNetworkWithRetryHelper.kt
@@ -28,14 +28,13 @@ class RequestNetworkWithRetryHelperImpl : RequestNetworkWithRetryHelper {
       )
     } catch (e: Exception) {
       Handler(Looper.getMainLooper()).postDelayed({
+        // Retry after 500ms is the requestNetwork call fails for any reason.
         try {
           connectivityManager.requestNetwork(
             networkRequest,
             networkCallback
           )
         } catch (retryException: Exception) {
-          // A failed retry is backstopped by the timeout in RequestManager. A logging hook will
-          // report this once the SDK has a logging mechanism.
         }
       }, 500)
     }

--- a/verify_sna/src/main/java/com/twilio/verify_sna/networking/RequestNetworkWithRetryHelper.kt
+++ b/verify_sna/src/main/java/com/twilio/verify_sna/networking/RequestNetworkWithRetryHelper.kt
@@ -7,10 +7,18 @@ import android.os.Handler
 import android.os.Looper
 
 interface RequestNetworkWithRetryHelper {
+  /**
+   * Registers [networkCallback] for [networkRequest], retrying once if the registration fails.
+   *
+   * @param onFailure invoked with the retry's exception when both attempts fail. The callback
+   * never registers in that case, so callers must report the failure themselves or they will
+   * wait for their own timeout with no indication of what went wrong.
+   */
   operator fun invoke(
     connectivityManager: ConnectivityManager,
     networkRequest: NetworkRequest,
-    networkCallback: NetworkCallback
+    networkCallback: NetworkCallback,
+    onFailure: (Exception) -> Unit
   )
 }
 
@@ -19,7 +27,8 @@ class RequestNetworkWithRetryHelperImpl : RequestNetworkWithRetryHelper {
   override operator fun invoke(
     connectivityManager: ConnectivityManager,
     networkRequest: NetworkRequest,
-    networkCallback: NetworkCallback
+    networkCallback: NetworkCallback,
+    onFailure: (Exception) -> Unit
   ) {
     try {
       connectivityManager.requestNetwork(
@@ -35,6 +44,7 @@ class RequestNetworkWithRetryHelperImpl : RequestNetworkWithRetryHelper {
             networkCallback
           )
         } catch (retryException: Exception) {
+          onFailure(retryException)
         }
       }, 500)
     }

--- a/verify_sna/src/main/java/com/twilio/verify_sna/networking/RequestNetworkWithRetryHelper.kt
+++ b/verify_sna/src/main/java/com/twilio/verify_sna/networking/RequestNetworkWithRetryHelper.kt
@@ -28,9 +28,6 @@ class RequestNetworkWithRetryHelperImpl : RequestNetworkWithRetryHelper {
       )
     } catch (e: Exception) {
       Handler(Looper.getMainLooper()).postDelayed({
-        // Guard the retry so a second failure doesn't crash the main thread. If the retry also
-        // fails the continuation won't resume here, but the timeout in RequestManager backstops
-        // that case by cancelling the request and unregistering the callback.
         try {
           connectivityManager.requestNetwork(
             networkRequest,

--- a/verify_sna/src/main/java/com/twilio/verify_sna/networking/RequestNetworkWithRetryHelper.kt
+++ b/verify_sna/src/main/java/com/twilio/verify_sna/networking/RequestNetworkWithRetryHelper.kt
@@ -34,7 +34,8 @@ class RequestNetworkWithRetryHelperImpl : RequestNetworkWithRetryHelper {
             networkCallback
           )
         } catch (retryException: Exception) {
-          retryException.printStackTrace()
+          // A failed retry is backstopped by the timeout in RequestManager. A logging hook will
+          // report this once the SDK has a logging mechanism.
         }
       }, 500)
     }

--- a/verify_sna/src/main/java/com/twilio/verify_sna/networking/VerifySnaNetworkCallbackProvider.kt
+++ b/verify_sna/src/main/java/com/twilio/verify_sna/networking/VerifySnaNetworkCallbackProvider.kt
@@ -30,9 +30,6 @@ class VerifySnaNetworkCallbackProviderImpl(
     continuation: Continuation<NetworkRequestResult>,
     connectivityManager: ConnectivityManager
   ): NetworkCallback {
-    // Network callbacks such as onCapabilitiesChanged can fire multiple times before the
-    // callback is unregistered. This guard guarantees the continuation is resumed exactly once,
-    // preventing "IllegalStateException: Already resumed" crashes.
     val hasResumed = AtomicBoolean(false)
     return object : NetworkCallback() {
       override fun onAvailable(network: Network) {
@@ -51,9 +48,6 @@ class VerifySnaNetworkCallbackProviderImpl(
           if (networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)) {
             performRequest(url, network, continuation, connectivityManager, this, hasResumed)
           }
-          // If the network is not validated yet we simply wait for a subsequent
-          // onCapabilitiesChanged. A network that never validates is backstopped by the
-          // timeout in RequestManager, which cancels the request and unregisters this callback.
         }
       }
     }
@@ -67,7 +61,6 @@ class VerifySnaNetworkCallbackProviderImpl(
     networkCallback: NetworkCallback,
     hasResumed: AtomicBoolean
   ) {
-    // Only the first invocation is allowed to resume the continuation and unregister the callback.
     if (!hasResumed.compareAndSet(false, true)) {
       return
     }

--- a/verify_sna/src/main/java/com/twilio/verify_sna/networking/VerifySnaNetworkCallbackProvider.kt
+++ b/verify_sna/src/main/java/com/twilio/verify_sna/networking/VerifySnaNetworkCallbackProvider.kt
@@ -7,6 +7,7 @@ import android.net.NetworkCapabilities
 import android.os.Build.VERSION
 import android.os.Build.VERSION_CODES
 import com.twilio.verify_sna.common.TwilioVerifySnaException
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
@@ -29,11 +30,15 @@ class VerifySnaNetworkCallbackProviderImpl(
     continuation: Continuation<NetworkRequestResult>,
     connectivityManager: ConnectivityManager
   ): NetworkCallback {
+    // Network callbacks such as onCapabilitiesChanged can fire multiple times before the
+    // callback is unregistered. This guard guarantees the continuation is resumed exactly once,
+    // preventing "IllegalStateException: Already resumed" crashes.
+    val hasResumed = AtomicBoolean(false)
     return object : NetworkCallback() {
       override fun onAvailable(network: Network) {
         super.onAvailable(network)
         if (VERSION.SDK_INT < VERSION_CODES.M) {
-          performRequest(url, network, continuation, connectivityManager, this)
+          performRequest(url, network, continuation, connectivityManager, this, hasResumed)
         }
       }
 
@@ -44,23 +49,11 @@ class VerifySnaNetworkCallbackProviderImpl(
         super.onCapabilitiesChanged(network, networkCapabilities)
         if (VERSION.SDK_INT >= VERSION_CODES.M) {
           if (networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)) {
-            performRequest(url, network, continuation, connectivityManager, this)
-          } else {
-            checkNetworkConnectivity(network)
+            performRequest(url, network, continuation, connectivityManager, this, hasResumed)
           }
-        }
-      }
-
-      private fun checkNetworkConnectivity(network: Network) {
-        try {
-          network.getByName("google.com").toString().isNotEmpty()
-        } catch (e: Exception) {
-          connectivityManager.unregisterNetworkCallback(this)
-          continuation.resumeWithException(
-            TwilioVerifySnaException.NetworkRequestException(
-              Exception("Network is not capable of connecting to internet"),
-            )
-          )
+          // If the network is not validated yet we simply wait for a subsequent
+          // onCapabilitiesChanged. A network that never validates is backstopped by the
+          // timeout in RequestManager, which cancels the request and unregisters this callback.
         }
       }
     }
@@ -71,8 +64,13 @@ class VerifySnaNetworkCallbackProviderImpl(
     network: Network,
     continuation: Continuation<NetworkRequestResult>,
     connectivityManager: ConnectivityManager,
-    networkCallback: NetworkCallback
+    networkCallback: NetworkCallback,
+    hasResumed: AtomicBoolean
   ) {
+    // Only the first invocation is allowed to resume the continuation and unregister the callback.
+    if (!hasResumed.compareAndSet(false, true)) {
+      return
+    }
     try {
       val networkRequestResult = networkRequestProvider.performRequest(url, network)
       continuation.resume(networkRequestResult)

--- a/verify_sna/src/test/java/com/twilio/verify_sna/domain/requestmanager/RequestManagerTest.kt
+++ b/verify_sna/src/test/java/com/twilio/verify_sna/domain/requestmanager/RequestManagerTest.kt
@@ -145,7 +145,7 @@ class RequestManagerTest {
         thrown = e
       }
       assertThat(thrown)
-        .isInstanceOf(TwilioVerifySnaException.NetworkRequestException::class.java)
+        .isInstanceOf(TwilioVerifySnaException.NetworkRequestTimeoutException::class.java)
       verify {
         connectivityManager.unregisterNetworkCallback(any<NetworkCallback>())
       }

--- a/verify_sna/src/test/java/com/twilio/verify_sna/domain/requestmanager/RequestManagerTest.kt
+++ b/verify_sna/src/test/java/com/twilio/verify_sna/domain/requestmanager/RequestManagerTest.kt
@@ -67,7 +67,8 @@ class RequestManagerTest {
       requestNetworkWithRetryHelper(
         connectivityManager,
         any(),
-        networkCallback
+        networkCallback,
+        any()
       )
     } answers {
       continuationSlot.captured.resume(expectedResult)
@@ -80,10 +81,85 @@ class RequestManagerTest {
       requestNetworkWithRetryHelper(
         connectivityManager,
         any(),
+        any(),
         any()
       )
     }
   }
+
+  @Test
+  fun `Process an Url surfaces the original cause when requesting the network keeps failing`() =
+    runTest {
+      val testUrl = "test.url.com"
+      val connectivityManager: ConnectivityManager = mockk(relaxed = true)
+      val requestNetworkException = SecurityException("CHANGE_NETWORK_STATE denied")
+
+      every {
+        context.getSystemService(Context.CONNECTIVITY_SERVICE)
+      } returns connectivityManager
+
+      every { isMobileDataEnabledHelper() } returns true
+
+      val onFailureSlot = slot<(Exception) -> Unit>()
+      every {
+        requestNetworkWithRetryHelper(
+          connectivityManager,
+          any(),
+          any(),
+          capture(onFailureSlot)
+        )
+      } answers {
+        onFailureSlot.captured(requestNetworkException)
+      }
+
+      var thrown: Throwable? = null
+      try {
+        requestManager.processUrl(testUrl)
+      } catch (e: Throwable) {
+        thrown = e
+      }
+
+      assertThat(thrown)
+        .isInstanceOf(TwilioVerifySnaException.NetworkRequestException::class.java)
+      assertThat(thrown).hasCauseThat().isSameInstanceAs(requestNetworkException)
+    }
+
+  @Test
+  fun `Process an Url ignores a retry failure reported after the request already timed out`() =
+    runTest {
+      val testUrl = "test.url.com"
+      val connectivityManager: ConnectivityManager = mockk(relaxed = true)
+
+      every {
+        context.getSystemService(Context.CONNECTIVITY_SERVICE)
+      } returns connectivityManager
+
+      every { isMobileDataEnabledHelper() } returns true
+
+      // Capture onFailure without resuming, so the request times out first.
+      val onFailureSlot = slot<(Exception) -> Unit>()
+      every {
+        requestNetworkWithRetryHelper(
+          connectivityManager,
+          any(),
+          any(),
+          capture(onFailureSlot)
+        )
+      } answers { }
+
+      var thrown: Throwable? = null
+      try {
+        requestManager.processUrl(testUrl)
+      } catch (e: Throwable) {
+        thrown = e
+      }
+      assertThat(thrown)
+        .isInstanceOf(TwilioVerifySnaException.NetworkRequestTimeoutException::class.java)
+
+      // The delayed retry reports its failure after the continuation was already cancelled.
+      // Resuming a cancelled continuation must be a no-op rather than a crash.
+      onFailureSlot.captured(SecurityException("CHANGE_NETWORK_STATE denied"))
+    }
 
   @Test
   fun `Process an Url returns Cellular Network Not Available exception`() = runTest {

--- a/verify_sna/src/test/java/com/twilio/verify_sna/domain/requestmanager/RequestManagerTest.kt
+++ b/verify_sna/src/test/java/com/twilio/verify_sna/domain/requestmanager/RequestManagerTest.kt
@@ -51,7 +51,7 @@ class RequestManagerTest {
     } returns connectivityManager
 
     every {
-      isMobileDataEnabledHelper(connectivityManager)
+      isMobileDataEnabledHelper()
     } returns true
 
     val continuationSlot = slot<Continuation<NetworkRequestResult>>()
@@ -95,7 +95,7 @@ class RequestManagerTest {
     } returns connectivityManager
 
     every {
-      isMobileDataEnabledHelper(connectivityManager)
+      isMobileDataEnabledHelper()
     } returns false
 
     try {
@@ -135,7 +135,7 @@ class RequestManagerTest {
       } returns connectivityManager
 
       every {
-        isMobileDataEnabledHelper(connectivityManager)
+        isMobileDataEnabledHelper()
       } returns true
 
       var thrown: Throwable? = null

--- a/verify_sna/src/test/java/com/twilio/verify_sna/domain/requestmanager/RequestManagerTest.kt
+++ b/verify_sna/src/test/java/com/twilio/verify_sna/domain/requestmanager/RequestManagerTest.kt
@@ -138,8 +138,6 @@ class RequestManagerTest {
         isMobileDataEnabledHelper(connectivityManager)
       } returns true
 
-      // requestNetworkWithRetryHelper is a relaxed mock that never resumes the continuation,
-      // so the 30s timeout must fire (runTest auto-advances virtual time when the dispatcher idles).
       var thrown: Throwable? = null
       try {
         requestManager.processUrl(testUrl)

--- a/verify_sna/src/test/java/com/twilio/verify_sna/domain/requestmanager/RequestManagerTest.kt
+++ b/verify_sna/src/test/java/com/twilio/verify_sna/domain/requestmanager/RequestManagerTest.kt
@@ -104,4 +104,52 @@ class RequestManagerTest {
       assertThat(e).isInstanceOf(TwilioVerifySnaException.CellularNetworkNotAvailable::class.java)
     }
   }
+
+  @Test
+  fun `Process an Url resumes with Cellular Network Not Available when ConnectivityManager is null`() =
+    runTest {
+      val testUrl = "test.url.com"
+
+      every {
+        context.getSystemService(Context.CONNECTIVITY_SERVICE)
+      } returns null
+
+      var thrown: Throwable? = null
+      try {
+        requestManager.processUrl(testUrl)
+      } catch (e: Throwable) {
+        thrown = e
+      }
+      assertThat(thrown)
+        .isInstanceOf(TwilioVerifySnaException.CellularNetworkNotAvailable::class.java)
+    }
+
+  @Test
+  fun `Process an Url resumes with Network Request Exception when the callback never resumes`() =
+    runTest {
+      val testUrl = "test.url.com"
+      val connectivityManager: ConnectivityManager = mockk(relaxed = true)
+
+      every {
+        context.getSystemService(Context.CONNECTIVITY_SERVICE)
+      } returns connectivityManager
+
+      every {
+        isMobileDataEnabledHelper(connectivityManager)
+      } returns true
+
+      // requestNetworkWithRetryHelper is a relaxed mock that never resumes the continuation,
+      // so the 30s timeout must fire (runTest auto-advances virtual time when the dispatcher idles).
+      var thrown: Throwable? = null
+      try {
+        requestManager.processUrl(testUrl)
+      } catch (e: Throwable) {
+        thrown = e
+      }
+      assertThat(thrown)
+        .isInstanceOf(TwilioVerifySnaException.NetworkRequestException::class.java)
+      verify {
+        connectivityManager.unregisterNetworkCallback(any<NetworkCallback>())
+      }
+    }
 }

--- a/verify_sna/src/test/java/com/twilio/verify_sna/networking/IsMobileDataEnabledHelperTest.kt
+++ b/verify_sna/src/test/java/com/twilio/verify_sna/networking/IsMobileDataEnabledHelperTest.kt
@@ -1,0 +1,48 @@
+package com.twilio.verify_sna.networking
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.telephony.TelephonyManager
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+class IsMobileDataEnabledHelperTest {
+
+  private val context: Context = mockk(relaxed = true)
+  private val connectivityManager: ConnectivityManager = mockk(relaxed = true)
+  private val telephonyManager: TelephonyManager = mockk(relaxed = true)
+
+  private val helper = IsMobileDataEnabledHelperImpl(context)
+
+  @Config(sdk = [28])
+  @Test
+  fun `Returns true when TelephonyManager reports data enabled on Android O and above`() {
+    every { context.getSystemService(Context.TELEPHONY_SERVICE) } returns telephonyManager
+    every { telephonyManager.isDataEnabled } returns true
+
+    assertThat(helper(connectivityManager)).isTrue()
+  }
+
+  @Config(sdk = [28])
+  @Test
+  fun `Returns false when TelephonyManager reports data disabled on Android O and above`() {
+    every { context.getSystemService(Context.TELEPHONY_SERVICE) } returns telephonyManager
+    every { telephonyManager.isDataEnabled } returns false
+
+    assertThat(helper(connectivityManager)).isFalse()
+  }
+
+  @Config(sdk = [28])
+  @Test
+  fun `Returns false when TelephonyManager is unavailable`() {
+    every { context.getSystemService(Context.TELEPHONY_SERVICE) } returns null
+
+    assertThat(helper(connectivityManager)).isFalse()
+  }
+}

--- a/verify_sna/src/test/java/com/twilio/verify_sna/networking/IsMobileDataEnabledHelperTest.kt
+++ b/verify_sna/src/test/java/com/twilio/verify_sna/networking/IsMobileDataEnabledHelperTest.kt
@@ -45,4 +45,13 @@ class IsMobileDataEnabledHelperTest {
 
     assertThat(helper(connectivityManager)).isFalse()
   }
+
+  @Config(sdk = [28])
+  @Test
+  fun `Returns false when reading data enabled state throws a SecurityException`() {
+    every { context.getSystemService(Context.TELEPHONY_SERVICE) } returns telephonyManager
+    every { telephonyManager.isDataEnabled } throws SecurityException("READ_PHONE_STATE denied")
+
+    assertThat(helper(connectivityManager)).isFalse()
+  }
 }

--- a/verify_sna/src/test/java/com/twilio/verify_sna/networking/IsMobileDataEnabledHelperTest.kt
+++ b/verify_sna/src/test/java/com/twilio/verify_sna/networking/IsMobileDataEnabledHelperTest.kt
@@ -26,7 +26,7 @@ class IsMobileDataEnabledHelperTest {
     every { context.getSystemService(Context.TELEPHONY_SERVICE) } returns telephonyManager
     every { telephonyManager.isDataEnabled } returns true
 
-    assertThat(helper(connectivityManager)).isTrue()
+    assertThat(helper()).isTrue()
   }
 
   @Config(sdk = [28])
@@ -35,7 +35,7 @@ class IsMobileDataEnabledHelperTest {
     every { context.getSystemService(Context.TELEPHONY_SERVICE) } returns telephonyManager
     every { telephonyManager.isDataEnabled } returns false
 
-    assertThat(helper(connectivityManager)).isFalse()
+    assertThat(helper()).isFalse()
   }
 
   @Config(sdk = [28])
@@ -43,7 +43,7 @@ class IsMobileDataEnabledHelperTest {
   fun `Returns false when TelephonyManager is unavailable`() {
     every { context.getSystemService(Context.TELEPHONY_SERVICE) } returns null
 
-    assertThat(helper(connectivityManager)).isFalse()
+    assertThat(helper()).isFalse()
   }
 
   @Config(sdk = [28])
@@ -52,6 +52,22 @@ class IsMobileDataEnabledHelperTest {
     every { context.getSystemService(Context.TELEPHONY_SERVICE) } returns telephonyManager
     every { telephonyManager.isDataEnabled } throws SecurityException("READ_PHONE_STATE denied")
 
-    assertThat(helper(connectivityManager)).isFalse()
+    assertThat(helper()).isFalse()
+  }
+
+  @Config(sdk = [25])
+  @Test
+  fun `Returns false when ConnectivityManager is unavailable below Android O`() {
+    every { context.getSystemService(Context.CONNECTIVITY_SERVICE) } returns null
+
+    assertThat(helper()).isFalse()
+  }
+
+  @Config(sdk = [25])
+  @Test
+  fun `Returns false when the hidden method is missing below Android O`() {
+    every { context.getSystemService(Context.CONNECTIVITY_SERVICE) } returns connectivityManager
+
+    assertThat(helper()).isFalse()
   }
 }

--- a/verify_sna/src/test/java/com/twilio/verify_sna/networking/NetworkRequestProviderTest.kt
+++ b/verify_sna/src/test/java/com/twilio/verify_sna/networking/NetworkRequestProviderTest.kt
@@ -61,4 +61,18 @@ class NetworkRequestProviderTest {
     networkRequestProvider.performRequest(baseUrl.toString(), mockNetwork)
     fail("Expected a TwilioVerifySnaException.NetworkRequestException to be thrown")
   }
+
+  @Test(expected = TwilioVerifySnaException.NetworkRequestException::class)
+  fun `Perform request wraps an IOException in a Network Request Exception`() {
+    server.start()
+    val baseUrl = server.url("/test")
+    // Close the server so the connection attempt fails with an IOException.
+    server.close()
+    every {
+      mockNetwork.socketFactory
+    } returns SocketFactory.getDefault()
+
+    networkRequestProvider.performRequest(baseUrl.toString(), mockNetwork)
+    fail("Expected a TwilioVerifySnaException.NetworkRequestException to be thrown")
+  }
 }

--- a/verify_sna/src/test/java/com/twilio/verify_sna/networking/NetworkRequestProviderTest.kt
+++ b/verify_sna/src/test/java/com/twilio/verify_sna/networking/NetworkRequestProviderTest.kt
@@ -66,7 +66,6 @@ class NetworkRequestProviderTest {
   fun `Perform request wraps an IOException in a Network Request Exception`() {
     server.start()
     val baseUrl = server.url("/test")
-    // Close the server so the connection attempt fails with an IOException.
     server.close()
     every {
       mockNetwork.socketFactory

--- a/verify_sna/src/test/java/com/twilio/verify_sna/networking/RequestNetworkWithRetryHelperTest.kt
+++ b/verify_sna/src/test/java/com/twilio/verify_sna/networking/RequestNetworkWithRetryHelperTest.kt
@@ -3,6 +3,7 @@ package com.twilio.verify_sna.networking
 import android.net.ConnectivityManager
 import android.net.ConnectivityManager.NetworkCallback
 import android.net.NetworkRequest
+import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -24,13 +25,17 @@ class RequestNetworkWithRetryHelperTest {
     val networkCallback: NetworkCallback = mockk(relaxed = true)
 
     val requestNetworkWithRetryHelper = RequestNetworkWithRetryHelperImpl()
+    var failure: Exception? = null
 
-    requestNetworkWithRetryHelper(connectivityManager, networkRequest, networkCallback)
+    requestNetworkWithRetryHelper(connectivityManager, networkRequest, networkCallback) {
+      failure = it
+    }
 
     // Then
     verify(exactly = 1) {
       connectivityManager.requestNetwork(networkRequest, networkCallback)
     }
+    assertThat(failure).isNull()
   }
 
   @Test
@@ -44,32 +49,41 @@ class RequestNetworkWithRetryHelperTest {
     } throws RuntimeException("first attempt failed") andThenAnswer { }
 
     val requestNetworkWithRetryHelper = RequestNetworkWithRetryHelperImpl()
+    var failure: Exception? = null
 
-    requestNetworkWithRetryHelper(connectivityManager, networkRequest, networkCallback)
+    requestNetworkWithRetryHelper(connectivityManager, networkRequest, networkCallback) {
+      failure = it
+    }
     shadowOf(Looper.getMainLooper()).idleFor(500, TimeUnit.MILLISECONDS)
 
     verify(exactly = 2) {
       connectivityManager.requestNetwork(networkRequest, networkCallback)
     }
+    assertThat(failure).isNull()
   }
 
   @Test
-  fun `Invoke request network does not propagate when the retry also fails`() {
+  fun `Invoke request network reports the retry exception when the retry also fails`() {
     val connectivityManager: ConnectivityManager = mockk(relaxed = true)
     val networkRequest: NetworkRequest = mockk(relaxed = true)
     val networkCallback: NetworkCallback = mockk(relaxed = true)
+    val retryException = SecurityException("CHANGE_NETWORK_STATE denied")
 
     every {
       connectivityManager.requestNetwork(networkRequest, networkCallback)
-    } throws RuntimeException("attempt failed")
+    } throws RuntimeException("first attempt failed") andThenThrows retryException
 
     val requestNetworkWithRetryHelper = RequestNetworkWithRetryHelperImpl()
+    var failure: Exception? = null
 
-    requestNetworkWithRetryHelper(connectivityManager, networkRequest, networkCallback)
+    requestNetworkWithRetryHelper(connectivityManager, networkRequest, networkCallback) {
+      failure = it
+    }
     shadowOf(Looper.getMainLooper()).idleFor(500, TimeUnit.MILLISECONDS)
 
     verify(exactly = 2) {
       connectivityManager.requestNetwork(networkRequest, networkCallback)
     }
+    assertThat(failure).isSameInstanceAs(retryException)
   }
 }

--- a/verify_sna/src/test/java/com/twilio/verify_sna/networking/RequestNetworkWithRetryHelperTest.kt
+++ b/verify_sna/src/test/java/com/twilio/verify_sna/networking/RequestNetworkWithRetryHelperTest.kt
@@ -39,7 +39,6 @@ class RequestNetworkWithRetryHelperTest {
     val networkRequest: NetworkRequest = mockk(relaxed = true)
     val networkCallback: NetworkCallback = mockk(relaxed = true)
 
-    // First call throws, second (retry) succeeds.
     every {
       connectivityManager.requestNetwork(networkRequest, networkCallback)
     } throws RuntimeException("first attempt failed") andThenAnswer { }
@@ -47,7 +46,6 @@ class RequestNetworkWithRetryHelperTest {
     val requestNetworkWithRetryHelper = RequestNetworkWithRetryHelperImpl()
 
     requestNetworkWithRetryHelper(connectivityManager, networkRequest, networkCallback)
-    // Advance past the 500ms postDelayed retry.
     shadowOf(Looper.getMainLooper()).idleFor(500, TimeUnit.MILLISECONDS)
 
     verify(exactly = 2) {
@@ -61,7 +59,6 @@ class RequestNetworkWithRetryHelperTest {
     val networkRequest: NetworkRequest = mockk(relaxed = true)
     val networkCallback: NetworkCallback = mockk(relaxed = true)
 
-    // Both the first call and the retry fail; the helper must swallow both.
     every {
       connectivityManager.requestNetwork(networkRequest, networkCallback)
     } throws RuntimeException("attempt failed")
@@ -69,7 +66,6 @@ class RequestNetworkWithRetryHelperTest {
     val requestNetworkWithRetryHelper = RequestNetworkWithRetryHelperImpl()
 
     requestNetworkWithRetryHelper(connectivityManager, networkRequest, networkCallback)
-    // Advancing past the 500ms retry must not throw.
     shadowOf(Looper.getMainLooper()).idleFor(500, TimeUnit.MILLISECONDS)
 
     verify(exactly = 2) {

--- a/verify_sna/src/test/java/com/twilio/verify_sna/networking/RequestNetworkWithRetryHelperTest.kt
+++ b/verify_sna/src/test/java/com/twilio/verify_sna/networking/RequestNetworkWithRetryHelperTest.kt
@@ -3,11 +3,15 @@ package com.twilio.verify_sna.networking
 import android.net.ConnectivityManager
 import android.net.ConnectivityManager.NetworkCallback
 import android.net.NetworkRequest
+import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import android.os.Looper
+import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
 class RequestNetworkWithRetryHelperTest {
@@ -25,6 +29,50 @@ class RequestNetworkWithRetryHelperTest {
 
     // Then
     verify(exactly = 1) {
+      connectivityManager.requestNetwork(networkRequest, networkCallback)
+    }
+  }
+
+  @Test
+  fun `Invoke request network schedules a retry when the first request fails`() {
+    val connectivityManager: ConnectivityManager = mockk(relaxed = true)
+    val networkRequest: NetworkRequest = mockk(relaxed = true)
+    val networkCallback: NetworkCallback = mockk(relaxed = true)
+
+    // First call throws, second (retry) succeeds.
+    every {
+      connectivityManager.requestNetwork(networkRequest, networkCallback)
+    } throws RuntimeException("first attempt failed") andThenAnswer { }
+
+    val requestNetworkWithRetryHelper = RequestNetworkWithRetryHelperImpl()
+
+    requestNetworkWithRetryHelper(connectivityManager, networkRequest, networkCallback)
+    // Advance past the 500ms postDelayed retry.
+    shadowOf(Looper.getMainLooper()).idleFor(500, TimeUnit.MILLISECONDS)
+
+    verify(exactly = 2) {
+      connectivityManager.requestNetwork(networkRequest, networkCallback)
+    }
+  }
+
+  @Test
+  fun `Invoke request network does not propagate when the retry also fails`() {
+    val connectivityManager: ConnectivityManager = mockk(relaxed = true)
+    val networkRequest: NetworkRequest = mockk(relaxed = true)
+    val networkCallback: NetworkCallback = mockk(relaxed = true)
+
+    // Both the first call and the retry fail; the helper must swallow both.
+    every {
+      connectivityManager.requestNetwork(networkRequest, networkCallback)
+    } throws RuntimeException("attempt failed")
+
+    val requestNetworkWithRetryHelper = RequestNetworkWithRetryHelperImpl()
+
+    requestNetworkWithRetryHelper(connectivityManager, networkRequest, networkCallback)
+    // Advancing past the 500ms retry must not throw.
+    shadowOf(Looper.getMainLooper()).idleFor(500, TimeUnit.MILLISECONDS)
+
+    verify(exactly = 2) {
       connectivityManager.requestNetwork(networkRequest, networkCallback)
     }
   }

--- a/verify_sna/src/test/java/com/twilio/verify_sna/networking/VerifySnaNetworkCallbackProviderTest.kt
+++ b/verify_sna/src/test/java/com/twilio/verify_sna/networking/VerifySnaNetworkCallbackProviderTest.kt
@@ -1,0 +1,79 @@
+package com.twilio.verify_sna.networking
+
+import android.net.ConnectivityManager
+import android.net.Network
+import android.net.NetworkCapabilities
+import com.google.common.truth.Truth.assertThat
+import com.twilio.verify_sna.common.TwilioVerifySnaException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.EmptyCoroutineContext
+
+@RunWith(RobolectricTestRunner::class)
+class VerifySnaNetworkCallbackProviderTest {
+
+  private val url = "test.url.com"
+  private val networkRequestProvider: NetworkRequestProvider = mockk(relaxed = true)
+  private val connectivityManager: ConnectivityManager = mockk(relaxed = true)
+  private val network: Network = mockk(relaxed = true)
+
+  private val results = mutableListOf<Result<NetworkRequestResult>>()
+  private val continuation = object : Continuation<NetworkRequestResult> {
+    override val context = EmptyCoroutineContext
+    override fun resumeWith(result: Result<NetworkRequestResult>) {
+      results.add(result)
+    }
+  }
+
+  private val provider = VerifySnaNetworkCallbackProviderImpl(networkRequestProvider)
+
+  private fun validatedCapabilities(): NetworkCapabilities {
+    val capabilities: NetworkCapabilities = mockk(relaxed = true)
+    every {
+      capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_VALIDATED)
+    } returns true
+    return capabilities
+  }
+
+  @Test
+  fun `Resumes the continuation only once when capabilities change multiple times`() {
+    val expectedResult = NetworkRequestResult(status = 200, message = "Success")
+    every { networkRequestProvider.performRequest(url, network) } returns expectedResult
+
+    val callback = provider.provide(url, continuation, connectivityManager)
+    val capabilities = validatedCapabilities()
+
+    // Simulate onCapabilitiesChanged firing repeatedly before the callback is unregistered.
+    callback.onCapabilitiesChanged(network, capabilities)
+    callback.onCapabilitiesChanged(network, capabilities)
+    callback.onCapabilitiesChanged(network, capabilities)
+
+    assertThat(results).hasSize(1)
+    assertThat(results.first().getOrNull()).isEqualTo(expectedResult)
+    verify(exactly = 1) {
+      connectivityManager.unregisterNetworkCallback(callback)
+    }
+  }
+
+  @Test
+  fun `Resumes with exception and unregisters when the request fails`() {
+    val exception = TwilioVerifySnaException.NetworkRequestException(Exception("boom"))
+    every { networkRequestProvider.performRequest(url, network) } throws exception
+
+    val callback = provider.provide(url, continuation, connectivityManager)
+
+    callback.onCapabilitiesChanged(network, validatedCapabilities())
+
+    assertThat(results).hasSize(1)
+    assertThat(results.first().exceptionOrNull())
+      .isInstanceOf(TwilioVerifySnaException.NetworkRequestException::class.java)
+    verify(exactly = 1) {
+      connectivityManager.unregisterNetworkCallback(callback)
+    }
+  }
+}

--- a/verify_sna/src/test/java/com/twilio/verify_sna/networking/VerifySnaNetworkCallbackProviderTest.kt
+++ b/verify_sna/src/test/java/com/twilio/verify_sna/networking/VerifySnaNetworkCallbackProviderTest.kt
@@ -48,7 +48,6 @@ class VerifySnaNetworkCallbackProviderTest {
     val callback = provider.provide(url, continuation, connectivityManager)
     val capabilities = validatedCapabilities()
 
-    // Simulate onCapabilitiesChanged firing repeatedly before the callback is unregistered.
     callback.onCapabilitiesChanged(network, capabilities)
     callback.onCapabilitiesChanged(network, capabilities)
     callback.onCapabilitiesChanged(network, capabilities)


### PR DESCRIPTION
## Summary

Addresses [CAS-996](https://twilio-engineering.atlassian.net/browse/CAS-996) — a set of stability improvements found in the SNA SDK. The ticket listed 14 issues; grounded against the current code these collapse into **7 root-cause fixes** across the SDK and sample app (several ticket items were duplicates, and a couple described stale code — e.g. there is no `performPostRequest`, only the GET `performRequest`, which is where the real unguarded `execute()` lives).

## SDK (`verify_sna`)

- **Multiple continuation resume + callback leak** (`VerifySnaNetworkCallbackProvider`): added an `AtomicBoolean` guard so the continuation resumes exactly once, and removed the leaky no-op success path in `checkNetworkConnectivity`. *(issues #1, #6, #12)*
- **Infinite hang** (`RequestManager`): wrapped the flow in `withTimeout(30s)` via `suspendCancellableCoroutine`, unregistering the callback on cancellation. *(issues #5, #8)*
- **Unsafe cast** (`RequestManager`): use `as?` for `ConnectivityManager` with null handling instead of a hard cast. *(issue #4)*
- **Handler/retry leak** (`RequestNetworkWithRetryHelper`): guarded the delayed retry so a second failure can't crash the main thread. *(issues #7, #11, #13)*
- **Unguarded `execute()`** (`NetworkRequestProvider`): wrap the OkHttp call so `IOException` surfaces as the typed `NetworkRequestException`. *(issues #9, #14)*
- **Reflection blocked on Android 10+** (`IsMobileDataEnabledHelper` + DI in `TwilioVerifySna`): use public `TelephonyManager.isDataEnabled()` on API 26+, falling back to reflection only below; `SecurityException` handled so no permission is forced on consumers. *(issue #10)*

## Sample app (`sample`)

- **VerifyingFragment**: build the SDK with `applicationContext` and run verification on `viewLifecycleOwner.lifecycleScope` with `isAdded` navigation guards, so a back-press mid-verification no longer crashes. *(issues #2, #3)*
- **WelcomeFragment**: same `TelephonyManager.isDataEnabled()` replacement. *(issue #10, sample side)*

## Tests

- New `VerifySnaNetworkCallbackProviderTest` and `IsMobileDataEnabledHelperTest`.
- Extended `RequestManagerTest` (null `ConnectivityManager`, timeout path), `NetworkRequestProviderTest` (IOException wrapping), and `RequestNetworkWithRetryHelperTest` (retry guarding).

## Verification

- `./gradlew ktlintCheck` ✅
- `./gradlew verify_sna:testDebugUnitTest` → 22 tests pass ✅
- `./gradlew verify_sna:koverXmlReportDebug verify_sna:koverVerify` ✅
- `./gradlew build` (incl. sample app + lint) ✅

## Out of scope

Version bump, CHANGELOG entry, and publishing were intentionally left out per the task scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)